### PR TITLE
Potential fix for code scanning alert no. 1: Implicit narrowing conversion in compound assignment

### DIFF
--- a/src/table/NetworkTable.java
+++ b/src/table/NetworkTable.java
@@ -289,7 +289,7 @@ public class NetworkTable extends JComponent implements ActionListener, Refresha
 		return map;
 	}
 
-	protected float zoom = 1.0f;
+	protected double zoom = 1.0;
 
         public void zoom(double factor) {
 		if (factor == 0.0f)


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/armitage/security/code-scanning/1](https://github.com/offsoc/armitage/security/code-scanning/1)

To fix the problem, we need to ensure that the type of the left-hand side of the compound assignment statement is at least as wide as the type of the right-hand side. In this case, we should change the type of the `zoom` variable from `float` to `double` to match the type of the `factor` parameter. This will prevent the implicit narrowing conversion and maintain the precision of the calculations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
