### PR TITLE
Potential fix for code scanning alert no. 3: Unsafe hostname verification

### DIFF
--- a/src/msf/MsgRpcImpl.java
+++ b/src/msf/MsgRpcImpl.java
@@ -50,9 +50,10 @@ public class MsgRpcImpl extends RpcConnectionImpl {
 				sc.init(null, trustManagers, new java.security.SecureRandom());
 
 				HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-				HttpsURLConnection.setDefaultHostnameVerifier( new HostnameVerifier() {
-					public boolean verify(String string,SSLSession ssls) {
-						return true;
+				HttpsURLConnection.setDefaultHostnameVerifier(new HostnameVerifier() {
+					public boolean verify(String hostname, SSLSession session) {
+						HostnameVerifier defaultVerifier = HttpsURLConnection.getDefaultHostnameVerifier();
+						return defaultVerifier.verify(hostname, session);
 					}
 				});
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/armitage/security/code-scanning/3](https://github.com/offsoc/armitage/security/code-scanning/3)

To fix the problem, we need to implement a proper `HostnameVerifier` that verifies the hostname against the certificate. This can be done by comparing the hostname with the certificate's subject alternative names (SANs) or the common name (CN).

- Modify the `HostnameVerifier` to perform actual hostname verification.
- Use the `HttpsURLConnection.getDefaultHostnameVerifier()` to delegate the verification to the default implementation provided by Java, which performs proper hostname verification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
